### PR TITLE
update /debian with /systemd content

### DIFF
--- a/debian/coredns.coredns-log.logrotate
+++ b/debian/coredns.coredns-log.logrotate
@@ -1,0 +1,13 @@
+/var/log/coredns.log {
+  rotate 5
+  size 10M
+  compress
+  notifempty
+}
+
+/var/log/coredns.err.log {
+  rotate 5
+  size 10M
+  compress
+  notifempty
+}

--- a/debian/coredns.service
+++ b/debian/coredns.service
@@ -11,10 +11,13 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
 User=coredns
-WorkingDirectory=~
+WorkingDirectory=/var/lib/coredns
 ExecStart=/usr/bin/coredns -conf=/etc/coredns/Corefile
 ExecReload=/bin/kill -SIGUSR1 $MAINPID
 Restart=on-failure
+StandardOutput=append:/var/log/coredns.log
+StandardError=append:/var/log/coredns.err.log
+
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/coredns.sysusers
+++ b/debian/coredns.sysusers
@@ -1,0 +1,1 @@
+u coredns - "CoreDNS is a DNS server that chains plugins" /var/lib/coredns

--- a/debian/coredns.tmpfiles
+++ b/debian/coredns.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/coredns 0755 coredns coredns -


### PR DESCRIPTION
Update /debian packaging to include the /systemd files.

Establishs a baseline for my local customizations. 

The systemd /files are copied into /debian, for debian packaging.